### PR TITLE
fixed double $ error

### DIFF
--- a/src/Gitolite/Gitolite.php
+++ b/src/Gitolite/Gitolite.php
@@ -190,7 +190,7 @@ class Gitolite
      */
     public function getRepo($name)
     {
-        return (isset($this->repos[$name])) ? $this->repos[$$name] : false;
+        return (isset($this->repos[$name])) ? $this->repos[$name] : false;
     }
     
     /**


### PR DESCRIPTION
getRepo method doesn't work properly because of the double $ sign.
