### PR TITLE
Add support for composer deployment via packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "homepage": "https://github.com/rafaelgou/gitolite-php",
     "require": {
         "php": ">=5.3.0",
-        "ornicar/php-git-repo": "*"
+        "ornicar/php-git-repo": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
With the provided "composer.json" file, your library can be deployed via composer. (http://getcomposer.org)
Once you'll merge my request, go to "http://packagist.org" and after creating an account, allow packagist as github hook.
This will allow users to use the last release of your library thanks to "composer update".
As example, see the composer.json of "php-git-repo" : https://github.com/ornicar/php-git-repo/blob/master/composer.json

don't hesitate if you have any question
