### PR TITLE
Alternate/proper fix for handling special Team name @all

### DIFF
--- a/src/Gitolite/Gitolite.php
+++ b/src/Gitolite/Gitolite.php
@@ -329,6 +329,11 @@ class Gitolite
 	public function import()
 	{
 		
+        $specialTeamAll = new Team();
+        $specialTeamAll->setName('all');
+        $this->addTeam($specialTeamAll);
+
+                
 		$file = file($this->getGitLocalRepositoryPath() . DIRECTORY_SEPARATOR . self::GITOLITE_CONF_DIR . DIRECTORY_SEPARATOR . self::GITOLITE_CONF_FILE);
 		
 		foreach($file as $line)
@@ -601,7 +606,8 @@ class Gitolite
     {
         $return = '';
         foreach ($this->getTeams() as $team) {
-            $return .= $team->render();
+            if($team->getName() !="all" )
+                $return .= $team->render();
         }
         return $return . PHP_EOL;
     }

--- a/src/Gitolite/Gitolite.php
+++ b/src/Gitolite/Gitolite.php
@@ -409,13 +409,7 @@ class Gitolite
 					if(substr($u, 0, 1) == '@')
 					{
 						$u = substr($u, 1);
-						
-						if($u!="all")
-                         			{
-			                         	   if( ! isset($this->teams[$u])) throw new \Exception('Undef. team');
-                        				   $acl->addTeam($this->teams[$u]);
-
-			                        }						
+						if( ! isset($this->teams[$u])) throw new \Exception('Undef. team');
 						
 						$acl->addTeam($this->teams[$u]);
 					}


### PR DESCRIPTION
Preventing the special team 'all'  getting added to the list of team had adverse affect(With earlier pull request)

With this pull request, I reverted those change.

Added a placeholder team called "@all", However while displaying team list, it is prevented from  getting rendered.





